### PR TITLE
Compile Fix BLE write character errors

### DIFF
--- a/esphome/components/daikin_madoka/daikin_madoka.cpp
+++ b/esphome/components/daikin_madoka/daikin_madoka.cpp
@@ -288,11 +288,11 @@ void DaikinMadoka::query_(uint16_t cmd, std::vector<uint8_t> args, int t_d) {
       if (!status) {
         break;
       }
-      ESP_LOGD(TAG, "[%s] esp_ble_gattc_write_char failed (%d of %d), status=%d", this->parent_->address_str().c_str(),
+      ESP_LOGD(TAG, "[%s] esp_ble_gattc_write_char failed (%d of %d), status=%d", this->parent_->address_str(),
                j + 1, BLE_SEND_MAX_RETRIES, status);
     }
     if (status) {
-      ESP_LOGE(TAG, "[%s] Command could not be sent, last status=%d", this->parent_->address_str().c_str(), status);
+      ESP_LOGE(TAG, "[%s] Command could not be sent, last status=%d", this->parent_->address_str(), status);
       return;
     }
   }


### PR DESCRIPTION
.c_str() has become obsolete as address_str() is already a string and therefore no longer requires to be converted.