### PR TITLE
Restore compatibility with ESPHome BLEClientBase API

### DIFF
--- a/esphome/components/daikin_madoka/daikin_madoka.cpp
+++ b/esphome/components/daikin_madoka/daikin_madoka.cpp
@@ -279,7 +279,7 @@ void DaikinMadoka::query_(uint16_t cmd, std::vector<uint8_t> args, int t_d) {
     return;
   }
   std::vector<std::vector<uint8_t>> chunks = this->split_payload_(payload);
-
+  const char *addr = this->parent_->address_str();
   for (auto chk : chunks) {
     esp_err_t status;
     for (int j = 0; j < BLE_SEND_MAX_RETRIES; j++) {
@@ -288,11 +288,11 @@ void DaikinMadoka::query_(uint16_t cmd, std::vector<uint8_t> args, int t_d) {
       if (!status) {
         break;
       }
-      ESP_LOGD(TAG, "[%s] esp_ble_gattc_write_char failed (%d of %d), status=%d", this->parent_->address_str().c_str(),
+      ESP_LOGD(TAG, "[%s] esp_ble_gattc_write_char failed (%d of %d), status=%d", addr,
                j + 1, BLE_SEND_MAX_RETRIES, status);
     }
     if (status) {
-      ESP_LOGE(TAG, "[%s] Command could not be sent, last status=%d", this->parent_->address_str().c_str(), status);
+      ESP_LOGE(TAG, "[%s] Command could not be sent, last status=%d", addr, status);
       return;
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

fix: restore compatibility with ESPHome BLEClientBase API changes

The address_str() method now returns const char*, causing compilation errors in daikin_madoka where .c_str() was used.
This change aligns the component with the new API and does not alter behavior.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
