### PR TITLE
daikin_madoka: sticky FAN_ONLY to survive BRC1H mode-revert (fixes #9)

### DIFF
--- a/esphome/components/daikin_madoka/daikin_madoka.cpp
+++ b/esphome/components/daikin_madoka/daikin_madoka.cpp
@@ -81,6 +81,7 @@ void DaikinMadoka::control(const ClimateCall &call) {
       this->query_(CMD_SET_OPERATION_MODE, std::vector<uint8_t>{0x20, 0x01, (uint8_t) mode_out}, 600);
     }
     this->query_(CMD_SET_SETTING_STATUS, std::vector<uint8_t>{0x20, 0x01, (uint8_t) status_out}, 200);
+    this->last_set_mode_ = mode;
   }
   std::vector<uint8_t> temp_setpoint_args;
   if (call.get_target_temperature_high().has_value()) {
@@ -341,8 +342,17 @@ void DaikinMadoka::parse_cb_(std::vector<uint8_t> msg) {
     case CMD_GET_OPERATION_MODE:
       // ESP_LOGI(TAG, "status: %d, mode: %d", this->cur_status_.status, this->cur_status_.mode);
       if (this->cur_status_.status) {
+        // Sticky FAN_ONLY: the BRC1H silently resets the transient fan flag and reverts
+        // CMD_GET_OPERATION_MODE back to the last main mode ~10-30s after our SET. The fan
+        // flag is not exposed in 0x0030 readbacks, so we trust the last HA-issued mode and
+        // ignore non-fan readbacks while the user-requested mode is FAN_ONLY.
+        if (this->last_set_mode_ == climate::CLIMATE_MODE_FAN_ONLY &&
+            this->cur_status_.mode != 0 && this->cur_status_.mode != 5) {
+          break;
+        }
         switch (this->cur_status_.mode) {
           case 0:
+          case 5:
             this->mode = climate::CLIMATE_MODE_FAN_ONLY;
             break;
           case 1:
@@ -360,6 +370,7 @@ void DaikinMadoka::parse_cb_(std::vector<uint8_t> msg) {
         }
       } else {
         this->mode = climate::CLIMATE_MODE_OFF;
+        this->last_set_mode_ = climate::CLIMATE_MODE_OFF;
       }
       break;
     case CMD_GET_SETPOINT:

--- a/esphome/components/daikin_madoka/daikin_madoka.h
+++ b/esphome/components/daikin_madoka/daikin_madoka.h
@@ -58,6 +58,10 @@ class DaikinMadoka : public climate::Climate, public esphome::ble_client::BLECli
   uint16_t wwr_handle_;
   SemaphoreHandle_t receive_semaphore_ = nullptr;
   Status cur_status_;
+  // Sticky last HA-set mode. The BRC1H stores the last non-fan operation_mode in 0x20
+  // and does not expose the fan flag in CMD_GET_OPERATION_MODE — without this we'd
+  // overwrite FAN_ONLY back to COOL/HEAT on every poll.
+  climate::ClimateMode last_set_mode_ = climate::CLIMATE_MODE_OFF;
 
   std::vector<std::vector<uint8_t>> split_payload_(std::vector<uint8_t> msg);
   std::vector<uint8_t> prepare_message_(uint16_t cmd, std::vector<uint8_t> args);


### PR DESCRIPTION
Fixes #9.

The BRC1H stores the last non-fan operation_mode in arg `0x20` of `CMD_GET_OPERATION_MODE` and does not expose the transient fan-only flag. After we send `SET_OPERATION_MODE 0x00` (or `0x05`), the controller correctly drives the fan coil in fan-only mode and the LCD shows the fan icon — but a few seconds later the byte at `0x20` reverts to the previously saved main mode. The next poll then silently overwrites `climate::mode = FAN_ONLY` back to `COOL`/`HEAT` in ESPHome, even though the unit is still running fan-only.

This PR adds a single sticky-state field, `last_set_mode_`, and short-circuits the readback path in `parse_cb_` while the user-requested mode is `FAN_ONLY`. While sticky is active, non-fan readbacks of `cur_status_.mode` are ignored. Any other HA-side `set_hvac_mode` (or an `OFF` from the controller) clears the guard immediately, so it's not a one-way trap.

Also maps `0x20 == 5` to `FAN_ONLY` — some firmware revisions return `5` after a `SET=5` while others return `0`, and we'd otherwise drop into the default case.

15 lines total across the component, no behaviour change for non-fan-only paths.

### Test plan

- [x] Set `climate.fan_only`, wait 60s, confirm `mode` stays `fan_only` (was reverting to `cool`/`heat` before).
- [x] After ESP32 boot, first poll picks up the actual BRC1H state (sticky defaults to `OFF` in RAM, so no false `FAN_ONLY` carry-over).
- [x] Setting any non-`FAN_ONLY` mode from HA clears the sticky guard; subsequent polls reflect the live mode again.
- [x] Setting `OFF` clears the sticky guard.

### Caveats

- Manual mode-switch on the BRC1H *away from* fan-only while HA last set fan-only won't be reflected until the next HA-side command. Acceptable trade: alternative is HA fighting back the fan flag every 10–30s.
- Workaround at the integration layer; the underlying BRC1H protocol still doesn't expose a fan flag. If a future firmware does, sticky can be removed in favour of trusting that flag.

Tested locally on two BRC1H controllers paired to a single ESP32 BLE proxy (ESPHome 2026.4.x, ESP-IDF 5.5.x) for two days — no regressions to cool/heat/heat_cool/dry behaviour observed.
