### PR TITLE
daikin_madoka: 5s cooldown between control() and the next poll

### DIFF
--- a/esphome/components/daikin_madoka/daikin_madoka.cpp
+++ b/esphome/components/daikin_madoka/daikin_madoka.cpp
@@ -45,6 +45,7 @@ void DaikinMadoka::loop() {
 void DaikinMadoka::control(const ClimateCall &call) {
   if (this->node_state != espbt::ClientState::ESTABLISHED)
     return;
+  this->last_control_ms_ = millis();
   if (call.get_mode().has_value()) {
     ClimateMode mode = *call.get_mode();
     uint8_t mode_out = 255, status_out = 0;
@@ -209,6 +210,11 @@ void DaikinMadoka::update() {
     ESP_LOGD(TAG, "...but device is disconnected");
     return;
   }
+  if (this->last_control_ms_ > 0 && millis() - this->last_control_ms_ < 5000) {
+    ESP_LOGD(TAG, "...skipping, cooldown after control command");
+    return;
+  }
+  this->last_control_ms_ = 0;
 
   std::vector<uint16_t> all_cmds{CMD_GET_SETTING_STATUS, CMD_GET_OPERATION_MODE, CMD_GET_SETPOINT, CMD_GET_FAN_SPEED,
                                  CMD_GET_SENSOR_INFORMATION};

--- a/esphome/components/daikin_madoka/daikin_madoka.h
+++ b/esphome/components/daikin_madoka/daikin_madoka.h
@@ -52,6 +52,7 @@ static const espbt::ESPBTUUID WWR_CHARACTERISTIC_UUID =
 class DaikinMadoka : public climate::Climate, public esphome::ble_client::BLEClientNode, public PollingComponent {
  protected:
   bool should_update_ = false;
+  uint32_t last_control_ms_{0};
   std::queue<std::vector<uint8_t>> received_chunks_ = {};
   std::map<uint8_t, std::vector<uint8_t>> pending_chunks_ = {};
   uint16_t notify_handle_;


### PR DESCRIPTION
After a `SET_OPERATION_MODE` / `SET_SETTING_STATUS` / `SET_SETPOINT` the BRC1H takes a few hundred milliseconds (sometimes much longer for `SET_OPERATION_MODE`, which the existing code already pauses 600ms after) to settle internally before its `GET_*` responses match what we just wrote. When `PollingComponent`'s next tick fires within that window the readback can return the *previous* state and overwrite `climate::mode` / `target_temperature` in ESPHome, leading to visible "set cool → flip back to fan_only briefly → flip to cool again" jitter in HA UI.

Stamp `millis()` on every `control()` and short-circuit `update()` for the next 5 seconds. After 5s the stamp clears and normal polling resumes.

No behaviour change in steady state — affects only the first 1–2 polls after a control command.

### Test plan

- [x] Set mode rapidly (`cool` → `heat` → `fan_only`) from HA, observe no transient flicker in `climate.*.mode` after each set.
- [x] Idle behaviour identical to upstream (`update()` continues to poll on schedule once cooldown expires).
