### PR TITLE
daikin_madoka: bump inter-query delay 50→200 ms in update() (multi-device fix)

### DIFF
--- a/esphome/components/daikin_madoka/daikin_madoka.cpp
+++ b/esphome/components/daikin_madoka/daikin_madoka.cpp
@@ -213,7 +213,7 @@ void DaikinMadoka::update() {
   std::vector<uint16_t> all_cmds{CMD_GET_SETTING_STATUS, CMD_GET_OPERATION_MODE, CMD_GET_SETPOINT, CMD_GET_FAN_SPEED,
                                  CMD_GET_SENSOR_INFORMATION};
   for (auto cmd : all_cmds) {
-    this->query_(cmd, std::vector<uint8_t>{0x00, 0x00}, 50);
+    this->query_(cmd, std::vector<uint8_t>{0x00, 0x00}, 200);
   }
 }
 


### PR DESCRIPTION
When two BRC1H controllers are paired through one ESP32 (single BLE proxy serving multiple rooms), 50 ms between the back-to-back `CMD_GET_*` queries in `update()` is too tight: chunked notifications from the two devices interleave, and `process_incoming_chunk_()` trips on

> `[E] Another packet with the same chunk ID is already in the buffer.`

followed shortly by

> `Dropped XX BLE events due to buffer overflow`

200 ms (the value `SET_SETTING_STATUS` and `SET_FAN_SPEED` already use) gives each device enough time to finish its notify chunks before the next query goes out. Total `update()` cycle goes from ~250 ms to ~1 s, well within `PollingComponent`'s default 60 s interval, so no perceptible polling slowdown.

One-line change.

### Test plan

- [x] Two BRC1H paired via one BLE proxy, default ESPHome `update_interval` — no more chunk-ID collisions in logs.
- [x] Single BRC1H — unchanged (slightly longer initial cycle by 750 ms, negligible).
