### PR TITLE
daikin_madoka: retry SET_SETTING_STATUS when BRC1H silently drops the chunk

### DIFF
--- a/esphome/components/daikin_madoka/daikin_madoka.cpp
+++ b/esphome/components/daikin_madoka/daikin_madoka.cpp
@@ -20,6 +20,12 @@ static const uint16_t CMD_GET_FAN_SPEED = 0x0050;
 static const uint16_t CMD_SET_FAN_SPEED = 0x4050;
 static const uint16_t CMD_GET_SENSOR_INFORMATION = 0x0110;
 
+// Status retry parameters: if the BRC1H reports a status that disagrees with
+// the last HA-issued status within this window, re-send SET_SETTING_STATUS up
+// to MAX_STATUS_RETRIES times before accepting the readback as truth.
+static const uint32_t STATUS_RETRY_WINDOW_MS = 30000;
+static const uint8_t MAX_STATUS_RETRIES = 2;
+
 void DaikinMadoka::dump_config() { LOG_CLIMATE(TAG, "Daikin Madoka Climate Controller", this); }
 
 void DaikinMadoka::setup() { this->receive_semaphore_ = xSemaphoreCreateMutex(); }
@@ -81,6 +87,9 @@ void DaikinMadoka::control(const ClimateCall &call) {
       this->query_(CMD_SET_OPERATION_MODE, std::vector<uint8_t>{0x20, 0x01, (uint8_t) mode_out}, 600);
     }
     this->query_(CMD_SET_SETTING_STATUS, std::vector<uint8_t>{0x20, 0x01, (uint8_t) status_out}, 200);
+    this->last_set_status_byte_ = static_cast<uint8_t>(status_out);
+    this->last_set_ms_ = millis();
+    this->status_retry_count_ = 0;
   }
   std::vector<uint8_t> temp_setpoint_args;
   if (call.get_target_temperature_high().has_value()) {
@@ -320,6 +329,25 @@ void DaikinMadoka::parse_cb_(std::vector<uint8_t> msg) {
           this->cur_status_.status = val[0];
         }
         i += len;
+      }
+      // Status retry guard — see header comment on last_set_status_byte_.
+      if (this->last_set_ms_ > 0 &&
+          (millis() - this->last_set_ms_) < STATUS_RETRY_WINDOW_MS &&
+          ((uint8_t) (this->cur_status_.status ? 1 : 0)) != this->last_set_status_byte_ &&
+          this->status_retry_count_ < MAX_STATUS_RETRIES) {
+        this->status_retry_count_++;
+        ESP_LOGW(TAG,
+                 "[%s] SETTING_STATUS readback mismatch (got=%d, expected=%d), retry %d/%d",
+                 this->get_name().c_str(),
+                 (int) (this->cur_status_.status ? 1 : 0),
+                 (int) this->last_set_status_byte_,
+                 (int) this->status_retry_count_,
+                 (int) MAX_STATUS_RETRIES);
+        this->query_(CMD_SET_SETTING_STATUS,
+                     std::vector<uint8_t>{0x20, 0x01, this->last_set_status_byte_}, 200);
+        // Don't let the rest of parse_cb_ act on the stale readback — pretend the
+        // pulse acknowledged what we asked for; the next poll round will confirm.
+        this->cur_status_.status = (this->last_set_status_byte_ != 0);
       }
       break;
     case CMD_GET_OPERATION_MODE:

--- a/esphome/components/daikin_madoka/daikin_madoka.h
+++ b/esphome/components/daikin_madoka/daikin_madoka.h
@@ -58,6 +58,15 @@ class DaikinMadoka : public climate::Climate, public esphome::ble_client::BLECli
   uint16_t wwr_handle_;
   SemaphoreHandle_t receive_semaphore_ = nullptr;
   Status cur_status_;
+  // Status retry guard. The BRC1H sometimes drops the SET_SETTING_STATUS chunk
+  // silently (typically when one ESP juggles two BRC1H pairs at once over BLE).
+  // The unit then stays physically off even though we just told it to turn on,
+  // and the next poll reports status=0 and flips climate::mode to OFF in HA.
+  // Remember the requested status for a short window and re-issue
+  // SET_SETTING_STATUS if the readback disagrees, up to a small cap.
+  uint8_t last_set_status_byte_{0};
+  uint32_t last_set_ms_{0};
+  uint8_t status_retry_count_{0};
 
   std::vector<std::vector<uint8_t>> split_payload_(std::vector<uint8_t> msg);
   std::vector<uint8_t> prepare_message_(uint16_t cmd, std::vector<uint8_t> args);


### PR DESCRIPTION
When one ESP32 proxies two BRC1H pairs over BLE, the back-to-back `SET_OPERATION_MODE` (600 ms) and `SET_SETTING_STATUS` (200 ms) emitted from `control()` occasionally have **one of the two chunks** silently dropped by one of the pulses. In the case this PR addresses, the dropped chunk is `SET_SETTING_STATUS`: `SET_OPERATION_MODE` goes through (LCD switches to the requested mode icon), but the on/off state does not — the unit stays physically off. Polling 5–15 s later reports `cur_status_.status = 0` and flips `climate::mode` to `OFF` in HA, surprising the user who just turned it on. The other paired BRC1H on the same ESP works fine in the same window.

The dropped chunk can be either of the two, not specifically the second one. The symmetric case — `SET_OPERATION_MODE` itself dropped while `SET_SETTING_STATUS` lands — produces a different symptom (mode silently reverts to the previous one within ~24 s of a HomeKit/HA mode change). That case is handled by the companion PR #15, which adds the same retry pattern for `CMD_GET_OPERATION_MODE`. Both retries share `STATUS_RETRY_WINDOW_MS` / `MAX_STATUS_RETRIES`.

The existing `BLE_SEND_MAX_RETRIES` loop in `query_()` only retries the raw chunk write; if all 5 writes succeed at the link layer but the pulse-side parser silently rejects them, we never know. This PR adds a higher-level status retry:

- Stash `last_set_status_byte_` + `last_set_ms_` + `status_retry_count_` whenever `control()` emits a `SET_SETTING_STATUS`.
- In `parse_cb_`, on `CMD_GET_SETTING_STATUS` readback within `STATUS_RETRY_WINDOW_MS` (30 s after control()) — if `cur_status_.status` disagrees with our intent, re-send `SET_SETTING_STATUS`, up to `MAX_STATUS_RETRIES` (2).
- Patch the local `cur_status_.status` so the downstream switch doesn't flip `climate::mode` to OFF based on the stale readback.

Independent of #10 (sticky fan_only) / #11 (control cooldown) / #12 (notify gate) / #13 (poll delay). Companion to #15 (symmetric `SET_OPERATION_MODE` retry).

### Caveats

- If the user toggled the unit on the BRC1H buttons within the same 30 s window, we'd fight back briefly. Acceptable: the user usually notices, the second retry settles, or a fresh `control()` resets the guard.
- 30 s window is conservative; in practice one retry resolves the disagreement within the same poll cycle.

### Test plan

- [x] Reproduced the "one of two fan coils stays off" case on two BRC1H over one ESP32; with this patch the second poll fires `SET_SETTING_STATUS` again and the unit catches up — no manual "press fan_only twice" needed.
- [x] Single BRC1H setup unaffected (`last_set_ms_` stays 0 until first `control()`).
- [x] Manual `OFF` from BRC1H buttons within window: HA shows the unit ON for ~10 s while retries fire, then accepts the off after retries exhaust. Tolerable trade-off vs. the symptom we fix.
