### PR TITLE
daikin_madoka: retry SET_OPERATION_MODE when BRC1H drops the chunk silently

### DIFF
--- a/esphome/components/daikin_madoka/daikin_madoka.cpp
+++ b/esphome/components/daikin_madoka/daikin_madoka.cpp
@@ -20,6 +20,12 @@ static const uint16_t CMD_GET_FAN_SPEED = 0x0050;
 static const uint16_t CMD_SET_FAN_SPEED = 0x4050;
 static const uint16_t CMD_GET_SENSOR_INFORMATION = 0x0110;
 
+// Status retry parameters: if the BRC1H reports a status that disagrees with
+// the last HA-issued status within this window, re-send SET_SETTING_STATUS up
+// to MAX_STATUS_RETRIES times before accepting the readback as truth.
+static const uint32_t STATUS_RETRY_WINDOW_MS = 30000;
+static const uint8_t MAX_STATUS_RETRIES = 2;
+
 void DaikinMadoka::dump_config() { LOG_CLIMATE(TAG, "Daikin Madoka Climate Controller", this); }
 
 void DaikinMadoka::setup() { this->receive_semaphore_ = xSemaphoreCreateMutex(); }
@@ -81,6 +87,9 @@ void DaikinMadoka::control(const ClimateCall &call) {
       this->query_(CMD_SET_OPERATION_MODE, std::vector<uint8_t>{0x20, 0x01, (uint8_t) mode_out}, 600);
     }
     this->query_(CMD_SET_SETTING_STATUS, std::vector<uint8_t>{0x20, 0x01, (uint8_t) status_out}, 200);
+    this->last_set_status_byte_ = static_cast<uint8_t>(status_out);
+    this->last_set_ms_ = millis();
+    this->status_retry_count_ = 0;
   }
   std::vector<uint8_t> temp_setpoint_args;
   if (call.get_target_temperature_high().has_value()) {
@@ -320,6 +329,25 @@ void DaikinMadoka::parse_cb_(std::vector<uint8_t> msg) {
           this->cur_status_.status = val[0];
         }
         i += len;
+      }
+      // Status retry guard — see header comment on last_set_status_byte_.
+      if (this->last_set_ms_ > 0 &&
+          (millis() - this->last_set_ms_) < STATUS_RETRY_WINDOW_MS &&
+          ((uint8_t) (this->cur_status_.status ? 1 : 0)) != this->last_set_status_byte_ &&
+          this->status_retry_count_ < MAX_STATUS_RETRIES) {
+        this->status_retry_count_++;
+        ESP_LOGW(TAG,
+                 "[%s] SETTING_STATUS readback mismatch (got=%d, expected=%d), retry %d/%d",
+                 this->get_name().c_str(),
+                 (int) (this->cur_status_.status ? 1 : 0),
+                 (int) this->last_set_status_byte_,
+                 (int) this->status_retry_count_,
+                 (int) MAX_STATUS_RETRIES);
+        this->query_(CMD_SET_SETTING_STATUS,
+                     std::vector<uint8_t>{0x20, 0x01, this->last_set_status_byte_}, 200);
+        // Don't let the rest of parse_cb_ act on the stale readback — pretend the
+        // pulse acknowledged what we asked for; the next poll round will confirm.
+        this->cur_status_.status = (this->last_set_status_byte_ != 0);
       }
       break;
     case CMD_GET_OPERATION_MODE:

--- a/esphome/components/daikin_madoka/daikin_madoka.cpp
+++ b/esphome/components/daikin_madoka/daikin_madoka.cpp
@@ -22,9 +22,19 @@ static const uint16_t CMD_GET_SENSOR_INFORMATION = 0x0110;
 
 // Status retry parameters: if the BRC1H reports a status that disagrees with
 // the last HA-issued status within this window, re-send SET_SETTING_STATUS up
-// to MAX_STATUS_RETRIES times before accepting the readback as truth.
+// to MAX_STATUS_RETRIES times before accepting the readback as truth. The
+// same parameters also gate the symmetric mode-retry below.
 static const uint32_t STATUS_RETRY_WINDOW_MS = 30000;
 static const uint8_t MAX_STATUS_RETRIES = 2;
+
+// FAN_ONLY is reported as either byte 0 or byte 5 depending on whether the
+// pulse treats it as a transient fan flag or as the main operation mode.
+// Treat both as the same outcome when comparing readback to requested mode.
+static inline bool madoka_mode_byte_equiv(uint8_t a, uint8_t b) {
+  if (a == b) return true;
+  if ((a == 0 && b == 5) || (a == 5 && b == 0)) return true;
+  return false;
+}
 
 void DaikinMadoka::dump_config() { LOG_CLIMATE(TAG, "Daikin Madoka Climate Controller", this); }
 
@@ -88,8 +98,10 @@ void DaikinMadoka::control(const ClimateCall &call) {
     }
     this->query_(CMD_SET_SETTING_STATUS, std::vector<uint8_t>{0x20, 0x01, (uint8_t) status_out}, 200);
     this->last_set_status_byte_ = static_cast<uint8_t>(status_out);
+    this->last_set_mode_byte_ = mode_out;  // 255 keeps mode-retry disabled for OFF (no SET_OPERATION_MODE was sent)
     this->last_set_ms_ = millis();
     this->status_retry_count_ = 0;
+    this->mode_retry_count_ = 0;
   }
   std::vector<uint8_t> temp_setpoint_args;
   if (call.get_target_temperature_high().has_value()) {
@@ -359,6 +371,30 @@ void DaikinMadoka::parse_cb_(std::vector<uint8_t> msg) {
           this->cur_status_.mode = val[0];
         }
         i += len;
+      }
+      // Mode retry guard — symmetric to the SETTING_STATUS retry above. If the
+      // last HA-issued SET_OPERATION_MODE was within the retry window and the
+      // pulse-reported byte still doesn't match (BLE drop or pulse hadn't
+      // applied yet), re-issue SET_OPERATION_MODE and pretend the readback
+      // already matched, so the switch below doesn't snap climate::mode back
+      // to the stale value. last_set_mode_byte_ == 255 means we haven't issued
+      // a mode-setting command (OFF doesn't go via OPERATION_MODE) — guard off.
+      if (this->last_set_ms_ > 0 &&
+          (millis() - this->last_set_ms_) < STATUS_RETRY_WINDOW_MS &&
+          this->last_set_mode_byte_ != 255 &&
+          !madoka_mode_byte_equiv(this->cur_status_.mode, this->last_set_mode_byte_) &&
+          this->mode_retry_count_ < MAX_STATUS_RETRIES) {
+        this->mode_retry_count_++;
+        ESP_LOGW(TAG,
+                 "[%s] OPERATION_MODE readback mismatch (got=%d, expected=%d), retry %d/%d",
+                 this->get_name().c_str(),
+                 (int) this->cur_status_.mode,
+                 (int) this->last_set_mode_byte_,
+                 (int) this->mode_retry_count_,
+                 (int) MAX_STATUS_RETRIES);
+        this->query_(CMD_SET_OPERATION_MODE,
+                     std::vector<uint8_t>{0x20, 0x01, this->last_set_mode_byte_}, 600);
+        this->cur_status_.mode = this->last_set_mode_byte_;
       }
       break;
     default:

--- a/esphome/components/daikin_madoka/daikin_madoka.h
+++ b/esphome/components/daikin_madoka/daikin_madoka.h
@@ -58,6 +58,15 @@ class DaikinMadoka : public climate::Climate, public esphome::ble_client::BLECli
   uint16_t wwr_handle_;
   SemaphoreHandle_t receive_semaphore_ = nullptr;
   Status cur_status_;
+  // Status retry guard. The BRC1H sometimes drops the SET_SETTING_STATUS chunk
+  // silently (typically when one ESP juggles two BRC1H pairs at once over BLE).
+  // The unit then stays physically off even though we just told it to turn on,
+  // and the next poll reports status=0 and flips climate::mode to OFF in HA.
+  // Remember the requested status for a short window and re-issue
+  // SET_SETTING_STATUS if the readback disagrees, up to a small cap.
+  uint8_t last_set_status_byte_{0};
+  uint32_t last_set_ms_{0};
+  uint8_t status_retry_count_{0};
 
   std::vector<std::vector<uint8_t>> split_payload_(std::vector<uint8_t> msg);
   std::vector<uint8_t> prepare_message_(uint16_t cmd, std::vector<uint8_t> args);

--- a/esphome/components/daikin_madoka/daikin_madoka.h
+++ b/esphome/components/daikin_madoka/daikin_madoka.h
@@ -67,6 +67,15 @@ class DaikinMadoka : public climate::Climate, public esphome::ble_client::BLECli
   uint8_t last_set_status_byte_{0};
   uint32_t last_set_ms_{0};
   uint8_t status_retry_count_{0};
+  // Mode retry guard, symmetric to the SETTING_STATUS retry above. Same drop
+  // scenario, this time for SET_OPERATION_MODE: chunk silently lost on BLE →
+  // next poll reports the old pulse-side mode → parse_cb_ flips climate::mode
+  // in HA back to that stale value. Remembering the raw byte we requested
+  // (0..5; 255 = unset, e.g. OFF which doesn't go via OPERATION_MODE) lets us
+  // re-issue SET_OPERATION_MODE up to MAX_STATUS_RETRIES times before
+  // accepting the readback as truth.
+  uint8_t last_set_mode_byte_{255};
+  uint8_t mode_retry_count_{0};
 
   std::vector<std::vector<uint8_t>> split_payload_(std::vector<uint8_t> msg);
   std::vector<uint8_t> prepare_message_(uint16_t cmd, std::vector<uint8_t> args);


### PR DESCRIPTION
## Summary

Symmetric counterpart to the SETTING_STATUS retry from #14: re-issues `SET_OPERATION_MODE` when the BRC1H reports a stale mode byte after a recent HA-side mode change, instead of letting `parse_cb_` flip `climate::mode` back to the stale value.

Stacks on #14 — please merge #14 first (or treat this as `#14 + this commit`). The diff itself is `+46 / -1` and only touches `daikin_madoka.{cpp,h}`.

## Why

When one ESP32 proxies two BRC1H pairs over BLE, the back-to-back `SET_OPERATION_MODE` (600 ms) emitted from `control()` occasionally has its chunk silently dropped by one of the pulses. The unit stays in its previous mode, and 5–15 s later the next `CMD_GET_OPERATION_MODE` poll reports the stale byte. `parse_cb_` then flips `climate::mode` in HA back to that value — surprising the user who just picked COOL/HEAT/AUTO.

Concrete repro seen today:
- Earlier scene-restore left both BRC1H pairs in FAN_ONLY (previous mode on pulse).
- 40 min later, a HomeKit `COOL` command went through; `SET_SETTING_STATUS` landed (unit physically on), but `SET_OPERATION_MODE` chunk was silently dropped at the pulse.
- HA showed `cool` for ~24 s, then the next poll returned `mode=0` (FAN_ONLY) and `parse_cb_` snapped HA back to `fan_only`.

The existing sticky-FAN_ONLY guard only protects against the inverse (pulse reverting FAN_ONLY back to a main mode), so it didn't help here. `BLE_SEND_MAX_RETRIES` only retries the link-layer chunk write — if the link accepts but the pulse parser silently rejects, we never know.

## How

- Stash the requested raw mode byte in `last_set_mode_byte_` on every `control()` call that emitted `SET_OPERATION_MODE` (255 means \"unset\", used for the OFF case where we don't send a mode byte).
- In `parse_cb_` for `CMD_GET_OPERATION_MODE`, after reading `cur_status_.mode`, compare it to `last_set_mode_byte_` within `STATUS_RETRY_WINDOW_MS`.
- On mismatch, re-issue `SET_OPERATION_MODE` (up to `MAX_STATUS_RETRIES`), then set `cur_status_.mode = last_set_mode_byte_` so the downstream switch doesn't snap `climate::mode` to the stale value while the retry is in flight. The next poll round confirms or triggers another retry.
- `madoka_mode_byte_equiv` treats byte 0 and byte 5 as equivalent — both decode to `CLIMATE_MODE_FAN_ONLY` downstream, and the BRC1H is free to switch between them.

Reuses the same `STATUS_RETRY_WINDOW_MS = 30000` / `MAX_STATUS_RETRIES = 2` constants as #14.

## Test plan

Verified on a dual-BRC1H ESP32 proxy that reproduced the original bug:

- [x] `fan_only → cool`, observed for 41 s — `cool` stable, no rollback (pre-fix: rolled back to `fan_only` after 24 s).
- [x] `cool → heat`, observed for 31 s — `heat` stable.
- [x] `heat → fan_only`, observed for 31 s — `fan_only` stable.
- [x] `fan_only → cool`, observed for 30 s — `cool` stable.
- [x] All `control()` paths still go through to the BRC1H (LCD mode icon flips immediately, fan setpoints land).
- [x] OFF path unchanged: `last_set_mode_byte_ = 255` keeps the guard disabled, no spurious retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)